### PR TITLE
re-factored out Java-based DNS lookup and its dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,28 +5,55 @@ import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 
 import scalariform.formatter.preferences._
 
-lazy val root = (project in file("."))
-  .settings( publishSettings: _* )
-  .aggregate(client, dockerTestkit, example)
+// Common variables
+lazy val commonSettings = Seq(
+  scalaVersion := "2.11.8",
+  organization := "nl.stormlantern",
+  version := "0.1.1",
+  resolvers ++= Dependencies.resolutionRepos,
+  scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
+  )
 
-lazy val client = (project in file("client"))
+lazy val root = (project in file("."))
+  .settings( commonSettings: _* )
+  .settings( publishSettings: _* )
+  .aggregate(client, dnsHelper, dockerTestkit, example)
+ 
+ 
+lazy val dnsHelper = (project in file("dns-helper"))
+  .settings( commonSettings: _* )
   .settings( publishSettings: _* )
   .settings(
-    name := "reactive-consul",
-    organization := "nl.stormlantern",
-    scalaVersion := "2.11.8",
-    version := "0.1.1",
+    name := "reactive-consul-dns",
     publishArtifact in Compile := true,
     publishArtifact in makePom := true,
     publishArtifact in Test := false,
     publishArtifact in IntegrationTest := false,
     fork := true,
-    resolvers ++= Dependencies.resolutionRepos,
+    libraryDependencies ++= Seq(
+      spotifyDns
+    ),
+    ScalariformKeys.preferences := ScalariformKeys.preferences.value
+      .setPreference(AlignSingleLineCaseStatements, true)
+      .setPreference(DoubleIndentClassDeclaration, true)
+      .setPreference(PreserveDanglingCloseParenthesis, true)
+      .setPreference(RewriteArrowSymbols, true)
+  )
+
+lazy val client = (project in file("client"))
+  .settings( commonSettings: _* )
+  .settings( publishSettings: _* )
+  .settings(
+    name := "reactive-consul",
+    publishArtifact in Compile := true,
+    publishArtifact in makePom := true,
+    publishArtifact in Test := false,
+    publishArtifact in IntegrationTest := false,
+    fork := true,
     libraryDependencies ++= Seq(
       sprayClient,
       sprayJson,
       akkaActor,
-      spotifyDns,
       slf4j,
       akkaSlf4j,
       scalaTest % "it,test",
@@ -46,14 +73,13 @@ lazy val client = (project in file("client"))
   .dependsOn(dockerTestkit % "it,compile-internal")
 
 lazy val dockerTestkit = (project in file("docker-testkit"))
+  .settings( commonSettings: _* )
   .settings(
-    resolvers ++= Dependencies.resolutionRepos,
     libraryDependencies ++= Seq(
       slf4j,
       scalaTest,
       spotifyDocker
-    ),
-    scalaVersion := "2.11.8"
+    )
   )
   .configs( IntegrationTest )
   .settings( Defaults.itSettings : _* )
@@ -63,7 +89,8 @@ lazy val dockerTestkit = (project in file("docker-testkit"))
 
 lazy val example = (project in file("example"))
   .aggregate(client)
-  .dependsOn(client)
+  .dependsOn(client, dnsHelper)
+  .settings( commonSettings: _* )
   .settings(
       libraryDependencies ++= Seq(
         sprayClient,
@@ -75,9 +102,11 @@ lazy val example = (project in file("example"))
   )
   .settings(
     fork := true,
-    libraryDependencies ++= Seq(akkaActor, sprayClient, sprayJson),
-    scalaVersion := "2.11.8",
-    scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
+    libraryDependencies ++= Seq(
+      akkaActor,
+      sprayClient,
+      sprayJson
+    )
   )
   .settings( publishSettings: _* )
   .enablePlugins(JavaAppPackaging)

--- a/dns-helper/src/main/scala/stormlantern/consul/client/Dns.scala
+++ b/dns-helper/src/main/scala/stormlantern/consul/client/Dns.scala
@@ -1,0 +1,13 @@
+package stormlantern.consul.client
+
+import java.net.URL
+import com.spotify.dns.DnsSrvResolvers
+import collection.JavaConversions._
+
+object DNS {
+  def lookup(consulAddress: String): URL = {
+    val resolver = DnsSrvResolvers.newBuilder().build()
+    val lookupResult = resolver.resolve(consulAddress).headOption.getOrElse(throw new RuntimeException(s"No record found for ${consulAddress}"))
+    new URL(s"http://${lookupResult.host()}:${lookupResult.port()}")
+  }
+}


### PR DESCRIPTION
I pulled the DNS lookup code out into its own jar so the Java dependencies do get includes for people not using the DNS lookup feature.

The main reason is the transitive inclusion of Guava 0.12 which is huge and very old. This approach should be reduce the size of dependencies by a large amount for me.