### PR TITLE
changed Base64 impl to use Java 8's internal version

### DIFF
--- a/client/src/main/scala/stormlantern/consul/client/dao/ConsulHttpProtocol.scala
+++ b/client/src/main/scala/stormlantern/consul/client/dao/ConsulHttpProtocol.scala
@@ -2,10 +2,10 @@ package stormlantern.consul.client.dao
 
 import java.util.UUID
 
-import org.parboiled.common.Base64
 import spray.json._
 
 import scala.util.control.NonFatal
+import java.util.Base64
 
 trait ConsulHttpProtocol extends DefaultJsonProtocol {
 
@@ -25,20 +25,21 @@ trait ConsulHttpProtocol extends DefaultJsonProtocol {
   implicit val binaryDataFormat = new JsonFormat[BinaryData] {
     override def read(json: JsValue): BinaryData = json match {
       case JsString(data) ⇒ try {
-        BinaryData(Base64.rfc2045().decode(data))
+        BinaryData(Base64.getMimeDecoder.decode(data))
       } catch {
         case NonFatal(e) ⇒ deserializationError("Expected base64 encoded binary data, but got " + data)
       }
       case x ⇒ deserializationError("Expected base64 encoded binary data as JsString, but got " + x)
     }
 
-    override def write(obj: BinaryData): JsValue = JsString(Base64.rfc2045().encodeToString(obj.data, false))
+    override def write(obj: BinaryData): JsValue = JsString(Base64.getMimeEncoder.encodeToString(obj.data))
   }
 
   implicit val serviceFormat = jsonFormat(
     (node: String, address: String, serviceId: String, serviceName: String, serviceTags: Option[Set[String]], serviceAddress: String, servicePort: Int) ⇒
       ServiceInstance(node, address, serviceId, serviceName, serviceTags.getOrElse(Set.empty), serviceAddress, servicePort),
-    "Node", "Address", "ServiceID", "ServiceName", "ServiceTags", "ServiceAddress", "ServicePort")
+    "Node", "Address", "ServiceID", "ServiceName", "ServiceTags", "ServiceAddress", "ServicePort"
+  )
   implicit val httpCheckFormat = jsonFormat(HttpHealthCheck, "HTTP", "Interval")
   implicit val scriptCheckFormat = jsonFormat(ScriptHealthCheck, "Script", "Interval")
   implicit val ttlCheckFormat = jsonFormat(TTLHealthCheck, "TTL")


### PR DESCRIPTION
This PR will remove the use of Base64 from parboiled via the spray-client. 

If the spray-client gets replaced by my akka-http you will need to use this PR to not bring in parboiled just to do Base64 encoding. 

THE CATCH, it forces the library to use Java 8 only.