### PR TITLE
serviceId <-> serviceName handling

### DIFF
--- a/client/src/main/scala/stormlantern/consul/client/ServiceBrokerActor.scala
+++ b/client/src/main/scala/stormlantern/consul/client/ServiceBrokerActor.scala
@@ -19,16 +19,16 @@ import scala.concurrent.duration._
 class ServiceBrokerActor(services: Set[ConnectionStrategy], serviceAvailabilityActorFactory: (ActorRefFactory, ServiceDefinition, ActorRef) ⇒ ActorRef)(implicit ec: ExecutionContext) extends Actor with ActorLogging {
 
   // Actor state
-  val indexedServices = services.map(s ⇒ (s.serviceDefinition.serviceId, s)).toMap
+  val indexedServices: Map[String, ConnectionStrategy] = services.map(s ⇒ (s.serviceDefinition.key, s)).toMap
   val loadbalancers: mutable.Map[String, ActorRef] = mutable.Map.empty
   val serviceAvailability: mutable.Set[ActorRef] = mutable.Set.empty
   val sessionId: Option[UUID] = None
 
   override def preStart(): Unit = {
     indexedServices.foreach {
-      case (serviceId, strategy) ⇒
-        loadbalancers.put(serviceId, strategy.loadBalancerFactory(context))
-        log.info(s"Starting service availability Actor for $serviceId")
+      case (key, strategy) ⇒
+        loadbalancers.put(key, strategy.loadBalancerFactory(context))
+        log.info(s"Starting service availability Actor for $key")
         val serviceAvailabilityActorRef = serviceAvailabilityActorFactory(context, strategy.serviceDefinition, self)
         serviceAvailabilityActorRef ! Start
         serviceAvailability += serviceAvailabilityActorRef
@@ -36,21 +36,21 @@ class ServiceBrokerActor(services: Set[ConnectionStrategy], serviceAvailabilityA
   }
 
   def receive = {
-    case ServiceAvailabilityUpdate(added, removed) ⇒
-      log.debug(s"Adding connection providers for $added")
-      addConnectionProviders(added)
-      log.debug(s"Removing conection providers for $removed")
-      removeConnectionProviders(removed)
-    case GetServiceConnection(serviceId: String) ⇒
-      log.debug(s"Getting a service connection for $serviceId")
-      loadbalancers.get(serviceId) match {
+    case ServiceAvailabilityUpdate(key, added, removed) ⇒
+      log.debug(s"Adding connection providers for $key: $added")
+      addConnectionProviders(key, added)
+      log.debug(s"Removing conection providers for $key: $removed")
+      removeConnectionProviders(key, removed)
+    case GetServiceConnection(key: String) ⇒
+      log.debug(s"Getting a service connection for $key")
+      loadbalancers.get(key) match {
         case Some(loadbalancer) ⇒
           loadbalancer forward GetConnection
         case None ⇒
-          sender ! Failure(new ServiceUnavailableException(serviceId))
+          sender ! Failure(new ServiceUnavailableException(key))
       }
-    case HasAvailableConnectionProviderFor(serviceId: String) ⇒
-      loadbalancers.get(serviceId) match {
+    case HasAvailableConnectionProviderFor(key: String) ⇒
+      loadbalancers.get(key) match {
         case Some(loadbalancer) ⇒
           loadbalancer forward HasAvailableConnectionProvider
         case None ⇒
@@ -64,22 +64,22 @@ class ServiceBrokerActor(services: Set[ConnectionStrategy], serviceAvailabilityA
   }
 
   // Internal methods
-  def addConnectionProviders(added: Set[ServiceInstance]): Unit = {
+  def addConnectionProviders(key: String, added: Set[ServiceInstance]): Unit = {
     added.foreach { s ⇒
       val host = if (s.serviceAddress.isEmpty) s.address else s.serviceAddress
-      val connectionProvider = indexedServices(s.serviceId).connectionProviderFactory.create(host, s.servicePort)
-      loadbalancers(s.serviceId) ! LoadBalancerActor.AddConnectionProvider(s.serviceId, connectionProvider)
+      val connectionProvider = indexedServices(key).connectionProviderFactory.create(host, s.servicePort)
+      loadbalancers(key) ! LoadBalancerActor.AddConnectionProvider(s.serviceId, connectionProvider)
     }
   }
 
-  def removeConnectionProviders(removed: Set[ServiceInstance]): Unit = {
+  def removeConnectionProviders(key: String, removed: Set[ServiceInstance]): Unit = {
     removed.foreach { s ⇒
-      loadbalancers(s.serviceId) ! LoadBalancerActor.RemoveConnectionProvider(s.serviceId)
+      loadbalancers(key) ! LoadBalancerActor.RemoveConnectionProvider(s.serviceId)
     }
   }
 
   def queryConnectionProviderAvailability: Future[Boolean] = {
-    implicit val timeout = Timeout(1.second)
+    implicit val timeout: Timeout = 1.second
     import akka.pattern.ask
     Future.sequence(loadbalancers.values.map(_.ask(LoadBalancerActor.HasAvailableConnectionProvider).mapTo[Boolean])).map(_.forall(p ⇒ p))
   }
@@ -89,9 +89,9 @@ object ServiceBrokerActor {
   // Constructors
   def props(services: Set[ConnectionStrategy], serviceAvailabilityActorFactory: (ActorRefFactory, ServiceDefinition, ActorRef) ⇒ ActorRef)(implicit ec: ExecutionContext): Props = Props(new ServiceBrokerActor(services, serviceAvailabilityActorFactory))
   // Public messages
-  case class GetServiceConnection(serviceId: String)
+  case class GetServiceConnection(key: String)
   case object Stop
-  case class HasAvailableConnectionProviderFor(serviceId: String)
+  case class HasAvailableConnectionProviderFor(key: String)
   case object AllConnectionProvidersAvailable
   case class JoinElection(key: String)
 }

--- a/client/src/main/scala/stormlantern/consul/client/discovery/ConnectionHolder.scala
+++ b/client/src/main/scala/stormlantern/consul/client/discovery/ConnectionHolder.scala
@@ -5,7 +5,7 @@ import akka.actor.ActorRef
 import scala.concurrent.Future
 
 trait ConnectionHolder {
-  def key: String
+  def id: String
   def loadBalancer: ActorRef
   def connection: Future[Any]
 }

--- a/client/src/main/scala/stormlantern/consul/client/discovery/ConnectionProvider.scala
+++ b/client/src/main/scala/stormlantern/consul/client/discovery/ConnectionProvider.scala
@@ -9,11 +9,11 @@ trait ConnectionProvider {
   def getConnection: Future[Any]
   def returnConnection(connectionHolder: ConnectionHolder): Unit = ()
   def destroy(): Unit = ()
-  def getConnectionHolder(k: String, lb: ActorRef): Future[ConnectionHolder] = getConnection.map { connection ⇒
+  def getConnectionHolder(i: String, lb: ActorRef): Future[ConnectionHolder] = getConnection.map { connection ⇒
     new ConnectionHolder {
       override def connection: Future[Any] = getConnection
       override val loadBalancer: ActorRef = lb
-      override val key: String = k
+      override val id: String = i
     }
   }
 }

--- a/client/src/main/scala/stormlantern/consul/client/discovery/ConnectionStrategy.scala
+++ b/client/src/main/scala/stormlantern/consul/client/discovery/ConnectionStrategy.scala
@@ -3,7 +3,7 @@ package stormlantern.consul.client.discovery
 import akka.actor.{ ActorRef, ActorRefFactory }
 import stormlantern.consul.client.loadbalancers.{ LoadBalancer, LoadBalancerActor, RoundRobinLoadBalancer }
 
-case class ServiceDefinition(serviceId: String, serviceName: String, serviceTags: Set[String] = Set.empty, dataCenter: Option[String] = None)
+case class ServiceDefinition(key: String, serviceName: String, serviceTags: Set[String] = Set.empty, dataCenter: Option[String] = None)
 object ServiceDefinition {
 
   def apply(serviceName: String): ServiceDefinition = {
@@ -25,13 +25,13 @@ case class ConnectionStrategy(
 object ConnectionStrategy {
 
   def apply(serviceDefinition: ServiceDefinition, connectionProviderFactory: ConnectionProviderFactory, loadBalancer: LoadBalancer): ConnectionStrategy =
-    ConnectionStrategy(serviceDefinition, connectionProviderFactory, ctx ⇒ ctx.actorOf(LoadBalancerActor.props(loadBalancer, serviceDefinition.serviceId)))
+    ConnectionStrategy(serviceDefinition, connectionProviderFactory, ctx ⇒ ctx.actorOf(LoadBalancerActor.props(loadBalancer, serviceDefinition.key)))
 
   def apply(serviceDefinition: ServiceDefinition, connectionProviderFactory: (String, Int) ⇒ ConnectionProvider, loadBalancer: LoadBalancer): ConnectionStrategy = {
     val cpf = new ConnectionProviderFactory {
       override def create(host: String, port: Int): ConnectionProvider = connectionProviderFactory(host, port)
     }
-    ConnectionStrategy(serviceDefinition, cpf, ctx ⇒ ctx.actorOf(LoadBalancerActor.props(loadBalancer, serviceDefinition.serviceId)))
+    ConnectionStrategy(serviceDefinition, cpf, ctx ⇒ ctx.actorOf(LoadBalancerActor.props(loadBalancer, serviceDefinition.key)))
   }
 
   def apply(serviceName: String, connectionProviderFactory: (String, Int) ⇒ ConnectionProvider, loadBalancer: LoadBalancer): ConnectionStrategy = {

--- a/client/src/main/scala/stormlantern/consul/client/discovery/ServiceAvailabilityActor.scala
+++ b/client/src/main/scala/stormlantern/consul/client/discovery/ServiceAvailabilityActor.scala
@@ -50,8 +50,6 @@ object ServiceAvailabilityActor {
   // Messages
   case object Start
   private case class UpdateServiceAvailability(services: IndexedServiceInstances)
-  private[client] case class ServiceAvailabilityUpdate(key: String, added: Set[ServiceInstance], removed: Set[ServiceInstance])
-  private[client] object ServiceAvailabilityUpdate {
-    def empty = ServiceAvailabilityUpdate("", Set.empty, Set.empty)
-  }
+  private[client] case class ServiceAvailabilityUpdate(key: String, added: Set[ServiceInstance] = Set.empty,
+    removed: Set[ServiceInstance] = Set.empty)
 }

--- a/client/src/main/scala/stormlantern/consul/client/discovery/ServiceAvailabilityActor.scala
+++ b/client/src/main/scala/stormlantern/consul/client/discovery/ServiceAvailabilityActor.scala
@@ -38,7 +38,7 @@ class ServiceAvailabilityActor(httpClient: ConsulHttpClient, serviceDefinition: 
   def createServiceAvailabilityUpdate(oldState: IndexedServiceInstances, newState: IndexedServiceInstances): ServiceAvailabilityUpdate = {
     val deleted = oldState.resource.diff(newState.resource)
     val added = newState.resource.diff(oldState.resource)
-    ServiceAvailabilityUpdate(added, deleted)
+    ServiceAvailabilityUpdate(serviceDefinition.key, added, deleted)
   }
 
 }
@@ -50,8 +50,8 @@ object ServiceAvailabilityActor {
   // Messages
   case object Start
   private case class UpdateServiceAvailability(services: IndexedServiceInstances)
-  private[client] case class ServiceAvailabilityUpdate(added: Set[ServiceInstance], removed: Set[ServiceInstance])
+  private[client] case class ServiceAvailabilityUpdate(key: String, added: Set[ServiceInstance], removed: Set[ServiceInstance])
   private[client] object ServiceAvailabilityUpdate {
-    def empty = ServiceAvailabilityUpdate(Set.empty, Set.empty)
+    def empty = ServiceAvailabilityUpdate("", Set.empty, Set.empty)
   }
 }

--- a/client/src/main/scala/stormlantern/consul/client/loadbalancers/LoadBalancerActor.scala
+++ b/client/src/main/scala/stormlantern/consul/client/loadbalancers/LoadBalancerActor.scala
@@ -8,7 +8,7 @@ import stormlantern.consul.client.ServiceUnavailableException
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.collection.mutable
 
-class LoadBalancerActor(loadBalancer: LoadBalancer, service: String) extends Actor with ActorLogging {
+class LoadBalancerActor(loadBalancer: LoadBalancer, key: String) extends Actor with ActorLogging {
 
   import akka.pattern.pipe
 
@@ -16,7 +16,7 @@ class LoadBalancerActor(loadBalancer: LoadBalancer, service: String) extends Act
   val connectionProviders = mutable.Map.empty[String, ConnectionProvider]
 
   override def postStop(): Unit = {
-    log.debug(s"LoadBalancerActor for $service stopped, destroying all connection providers")
+    log.debug(s"LoadBalancerActor for $key stopped, destroying all connection providers")
     connectionProviders.values.foreach(_.destroy())
   }
 
@@ -24,41 +24,41 @@ class LoadBalancerActor(loadBalancer: LoadBalancer, service: String) extends Act
 
     case GetConnection ⇒
       selectConnection match {
-        case Some((key, connectionProvider)) ⇒ connectionProvider.getConnectionHolder(key, self) pipeTo sender
-        case None                            ⇒ sender ! Failure(ServiceUnavailableException(service))
+        case Some((id, connectionProvider)) ⇒ connectionProvider.getConnectionHolder(id, self) pipeTo sender
+        case None                           ⇒ sender ! Failure(ServiceUnavailableException(key))
       }
-    case ReturnConnection(connection)         ⇒ returnConnection(connection)
-    case AddConnectionProvider(key, provider) ⇒ addConnectionProvider(key, provider)
-    case RemoveConnectionProvider(key)        ⇒ removeConnectionProvider(key)
-    case HasAvailableConnectionProvider       ⇒ sender ! connectionProviders.nonEmpty
+    case ReturnConnection(connection)        ⇒ returnConnection(connection)
+    case AddConnectionProvider(id, provider) ⇒ addConnectionProvider(id, provider)
+    case RemoveConnectionProvider(id)        ⇒ removeConnectionProvider(id)
+    case HasAvailableConnectionProvider      ⇒ sender ! connectionProviders.nonEmpty
   }
 
   def selectConnection: Option[(String, ConnectionProvider)] =
-    loadBalancer.selectConnection.flatMap(key ⇒ connectionProviders.get(key).map(key → _))
+    loadBalancer.selectConnection.flatMap(id ⇒ connectionProviders.get(id).map(id → _))
 
   def returnConnection(connection: ConnectionHolder): Unit = {
-    connectionProviders.get(connection.key).foreach(_.returnConnection(connection))
-    loadBalancer.connectionReturned(connection.key)
+    connectionProviders.get(connection.id).foreach(_.returnConnection(connection))
+    loadBalancer.connectionReturned(connection.id)
   }
 
-  def addConnectionProvider(key: String, provider: ConnectionProvider): Unit = {
-    connectionProviders.put(key, provider)
-    loadBalancer.connectionProviderAdded(key)
+  def addConnectionProvider(id: String, provider: ConnectionProvider): Unit = {
+    connectionProviders.put(id, provider)
+    loadBalancer.connectionProviderAdded(id)
   }
 
-  def removeConnectionProvider(key: String): Unit = {
-    connectionProviders.remove(key).foreach(_.destroy())
-    loadBalancer.connectionProviderRemoved(key)
+  def removeConnectionProvider(id: String): Unit = {
+    connectionProviders.remove(id).foreach(_.destroy())
+    loadBalancer.connectionProviderRemoved(id)
   }
 }
 
 object LoadBalancerActor {
   // Props
-  def props(loadBalancer: LoadBalancer, service: String) = Props(new LoadBalancerActor(loadBalancer, service))
+  def props(loadBalancer: LoadBalancer, key: String) = Props(new LoadBalancerActor(loadBalancer, key))
   // Messsages
   case object GetConnection
   case class ReturnConnection(connection: ConnectionHolder)
-  case class AddConnectionProvider(key: String, provider: ConnectionProvider)
-  case class RemoveConnectionProvider(key: String)
+  case class AddConnectionProvider(id: String, provider: ConnectionProvider)
+  case class RemoveConnectionProvider(id: String)
   case object HasAvailableConnectionProvider
 }

--- a/client/src/test/scala/stormlantern/consul/client/discovery/ServiceAvailabilityActorSpec.scala
+++ b/client/src/test/scala/stormlantern/consul/client/discovery/ServiceAvailabilityActorSpec.scala
@@ -23,7 +23,7 @@ class ServiceAvailabilityActorSpec(_system: ActorSystem) extends TestKit(_system
 
   "The ServiceAvailabilityActor" should "receive one service update when there are no changes" in {
     val httpClient: ConsulHttpClient = mock[ConsulHttpClient]
-    val sut = TestActorRef(ServiceAvailabilityActor.props(httpClient, ServiceDefinition("bogus"), self))
+    val sut = TestActorRef(ServiceAvailabilityActor.props(httpClient, ServiceDefinition("bogus123", "bogus"), self))
     (httpClient.getService _).expects("bogus", None, Some(0L), Some("1s"), None).returns(Future.successful(IndexedServiceInstances(1, Set.empty)))
     (httpClient.getService _).expects("bogus", None, Some(1L), Some("1s"), None).onCall { p ⇒
       sut.stop()
@@ -36,8 +36,8 @@ class ServiceAvailabilityActorSpec(_system: ActorSystem) extends TestKit(_system
 
   it should "receive two service updates when there is a change" in {
     val httpClient: ConsulHttpClient = mock[ConsulHttpClient]
-    lazy val sut = TestActorRef(ServiceAvailabilityActor.props(httpClient, ServiceDefinition("bogus"), self))
-    val service = ModelHelpers.createService("bogus")
+    lazy val sut = TestActorRef(ServiceAvailabilityActor.props(httpClient, ServiceDefinition("bogus123", "bogus"), self))
+    val service = ModelHelpers.createService("bogus123", "bogus")
     (httpClient.getService _).expects("bogus", None, Some(0L), Some("1s"), None).returns(Future.successful(IndexedServiceInstances(1, Set.empty)))
     (httpClient.getService _).expects("bogus", None, Some(1L), Some("1s"), None).returns(Future.successful(IndexedServiceInstances(2, Set(service))))
     (httpClient.getService _).expects("bogus", None, Some(2L), Some("1s"), None).onCall { p ⇒
@@ -52,8 +52,8 @@ class ServiceAvailabilityActorSpec(_system: ActorSystem) extends TestKit(_system
 
   it should "receive one service update when there are two with different tags" in {
     val httpClient: ConsulHttpClient = mock[ConsulHttpClient]
-    lazy val sut = TestActorRef(ServiceAvailabilityActor.props(httpClient, ServiceDefinition("bogus", Set("one", "two")), self))
-    val nonMatchingservice = ModelHelpers.createService("bogus", tags = Set("one"))
+    lazy val sut = TestActorRef(ServiceAvailabilityActor.props(httpClient, ServiceDefinition("bogus123", "bogus", Set("one", "two")), self))
+    val nonMatchingservice = ModelHelpers.createService("bogus123", "bogus", tags = Set("one"))
     val matchingService = nonMatchingservice.copy(serviceTags = Set("one", "two"))
     (httpClient.getService _).expects("bogus", Some("one"), Some(0L), Some("1s"), None).returns(Future.successful(IndexedServiceInstances(1, Set.empty)))
     (httpClient.getService _).expects("bogus", Some("one"), Some(1L), Some("1s"), None).returns(Future.successful(IndexedServiceInstances(2, Set(nonMatchingservice, matchingService))))

--- a/client/src/test/scala/stormlantern/consul/client/discovery/ServiceAvailabilityActorSpec.scala
+++ b/client/src/test/scala/stormlantern/consul/client/discovery/ServiceAvailabilityActorSpec.scala
@@ -46,7 +46,7 @@ class ServiceAvailabilityActorSpec(_system: ActorSystem) extends TestKit(_system
     }
     sut ! Start
     expectMsg(1.second, ServiceAvailabilityActor.ServiceAvailabilityUpdate.empty)
-    expectMsg(1.second, ServiceAvailabilityActor.ServiceAvailabilityUpdate(Set(service), Set.empty))
+    expectMsg(1.second, ServiceAvailabilityActor.ServiceAvailabilityUpdate("bugus123", Set(service), Set.empty))
     expectNoMsg(1.second)
   }
 
@@ -63,7 +63,7 @@ class ServiceAvailabilityActorSpec(_system: ActorSystem) extends TestKit(_system
     }
     sut ! Start
     expectMsg(1.second, ServiceAvailabilityActor.ServiceAvailabilityUpdate.empty)
-    expectMsg(1.second, ServiceAvailabilityActor.ServiceAvailabilityUpdate(Set(matchingService), Set.empty))
+    expectMsg(1.second, ServiceAvailabilityActor.ServiceAvailabilityUpdate("bugus123", Set(matchingService), Set.empty))
     expectNoMsg(1.second)
   }
 }

--- a/client/src/test/scala/stormlantern/consul/client/discovery/ServiceAvailabilityActorSpec.scala
+++ b/client/src/test/scala/stormlantern/consul/client/discovery/ServiceAvailabilityActorSpec.scala
@@ -30,7 +30,7 @@ class ServiceAvailabilityActorSpec(_system: ActorSystem) extends TestKit(_system
       Future.successful(IndexedServiceInstances(1, Set.empty))
     }
     sut ! Start
-    expectMsg(1.second, ServiceAvailabilityActor.ServiceAvailabilityUpdate.empty)
+    expectMsg(1.second, ServiceAvailabilityActor.ServiceAvailabilityUpdate("bogus123"))
     expectNoMsg(1.second)
   }
 
@@ -45,8 +45,8 @@ class ServiceAvailabilityActorSpec(_system: ActorSystem) extends TestKit(_system
       Future.successful(IndexedServiceInstances(2, Set(service)))
     }
     sut ! Start
-    expectMsg(1.second, ServiceAvailabilityActor.ServiceAvailabilityUpdate.empty)
-    expectMsg(1.second, ServiceAvailabilityActor.ServiceAvailabilityUpdate("bugus123", Set(service), Set.empty))
+    expectMsg(1.second, ServiceAvailabilityActor.ServiceAvailabilityUpdate("bogus123"))
+    expectMsg(1.second, ServiceAvailabilityActor.ServiceAvailabilityUpdate("bogus123", Set(service), Set.empty))
     expectNoMsg(1.second)
   }
 
@@ -62,8 +62,8 @@ class ServiceAvailabilityActorSpec(_system: ActorSystem) extends TestKit(_system
       Future.successful(IndexedServiceInstances(2, Set(nonMatchingservice, matchingService)))
     }
     sut ! Start
-    expectMsg(1.second, ServiceAvailabilityActor.ServiceAvailabilityUpdate.empty)
-    expectMsg(1.second, ServiceAvailabilityActor.ServiceAvailabilityUpdate("bugus123", Set(matchingService), Set.empty))
+    expectMsg(1.second, ServiceAvailabilityActor.ServiceAvailabilityUpdate("bogus123"))
+    expectMsg(1.second, ServiceAvailabilityActor.ServiceAvailabilityUpdate("bogus123", Set(matchingService), Set.empty))
     expectNoMsg(1.second)
   }
 }

--- a/client/src/test/scala/stormlantern/consul/client/helpers/ModelHelpers.scala
+++ b/client/src/test/scala/stormlantern/consul/client/helpers/ModelHelpers.scala
@@ -1,15 +1,17 @@
 package stormlantern.consul.client.helpers
 
 import stormlantern.consul.client.dao.ServiceInstance
+import stormlantern.consul.client.discovery.ServiceDefinition
 
 object ModelHelpers {
-  def createService(name: String, port: Int = 666, node: String = "node", tags: Set[String] = Set.empty) = ServiceInstance(
+  def createService(id: String, name: String, port: Int = 666, node: String = "node", tags: Set[String] = Set.empty) = ServiceInstance(
     node = node,
     address = s"${node}Address",
-    serviceId = s"${name}Id",
+    serviceId = id,
     serviceName = name,
     serviceTags = tags,
     serviceAddress = s"${name}Address",
     servicePort = port
   )
+  def createService(service: ServiceDefinition): ServiceInstance = createService(service.serviceId, service.serviceName)
 }

--- a/client/src/test/scala/stormlantern/consul/client/helpers/ModelHelpers.scala
+++ b/client/src/test/scala/stormlantern/consul/client/helpers/ModelHelpers.scala
@@ -13,5 +13,5 @@ object ModelHelpers {
     serviceAddress = s"${name}Address",
     servicePort = port
   )
-  def createService(service: ServiceDefinition): ServiceInstance = createService(service.serviceId, service.serviceName)
+  def createService(service: ServiceDefinition): ServiceInstance = createService(service.key, service.serviceName)
 }

--- a/client/src/test/scala/stormlantern/consul/client/loadbalancers/LoadBalancerActorSpec.scala
+++ b/client/src/test/scala/stormlantern/consul/client/loadbalancers/LoadBalancerActorSpec.scala
@@ -53,9 +53,9 @@ class LoadBalancerActorSpec(_system: ActorSystem) extends TestKit(_system) with 
 
   it should "return a connection holder when requested" in new TestScope {
     val instanceKey = "instanceKey"
-    (connectionHolder.key _).expects().returns(instanceKey)
+    (connectionHolder.id _).expects().returns(instanceKey)
     (connectionProvider.returnConnection _).expects(connectionHolder)
-    (connectionHolder.key _).expects().returns(instanceKey)
+    (connectionHolder.id _).expects().returns(instanceKey)
     (loadBalancer.connectionReturned _).expects(instanceKey)
     (connectionProvider.destroy _).expects()
     val sut = TestActorRef(new LoadBalancerActor(loadBalancer, "service1"))
@@ -70,7 +70,7 @@ class LoadBalancerActorSpec(_system: ActorSystem) extends TestKit(_system) with 
     (connectionProvider.destroy _).expects()
     val sut = TestActorRef(new LoadBalancerActor(loadBalancer, "service1"))
     sut ! LoadBalancerActor.AddConnectionProvider(instanceKey, connectionProvider)
-    sut.underlyingActor.connectionProviders should contain(instanceKey -> connectionProvider)
+    sut.underlyingActor.connectionProviders should contain(instanceKey → connectionProvider)
     sut.stop()
   }
 
@@ -81,7 +81,7 @@ class LoadBalancerActorSpec(_system: ActorSystem) extends TestKit(_system) with 
     val sut = TestActorRef(new LoadBalancerActor(loadBalancer, "service1"))
     sut.underlyingActor.connectionProviders.put(instanceKey, connectionProvider)
     sut ! LoadBalancerActor.RemoveConnectionProvider(instanceKey)
-    sut.underlyingActor.connectionProviders should not contain (instanceKey -> connectionProvider)
+    sut.underlyingActor.connectionProviders should not contain (instanceKey → connectionProvider)
   }
 
   it should "return true when it has at least one available connection provider for the service" in new TestScope {


### PR DESCRIPTION
The following example has multiple `ServiceDefinition` with the same name but different tags, currently this scenario doesnt work and the `ServiceBrokerActor` at line 70 throws a `NoSuchElement` exception since the lookup is by name and not by id. In most cases this works because id == name but if name and id differ it was broken; This PR fixes it.

```
ServiceDefinition("http.service1", "service1", Set("http"))
ServiceDefinition("gprc.service1", "service1", Set("grpc"))
```